### PR TITLE
Fix image name typo in deployment.yml

### DIFF
--- a/sample-pipeline/deployment.yml
+++ b/sample-pipeline/deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: sample-container
-          image: ginx:1.25   # Replace with your app image
+          image: nginx:1.25   # Replace with your app image
           ports:
             - containerPort: 80
           resources:


### PR DESCRIPTION
This PR fixes the image name typo from 'ginx:1.25' to 'nginx:1.25' in the deployment.yml file.